### PR TITLE
Use keydown instead of keypress to support Chrome on Mac

### DIFF
--- a/www/main.js
+++ b/www/main.js
@@ -12,7 +12,7 @@
 	}
 	editor.setValue(savedCode, 1);
 
-	$("#code").on("keypress", function(e) {
+	$("#code").on("keydown", function(e) {
 		var meta = e.metaKey || e.ctrlKey;
 		var enterKey = (e.keyCode || e.which);
 		var enter = enterKey === 10 || enterKey === 13;


### PR DESCRIPTION
CMD+enter did not work on Mac under Chrome. According to this: http://stackoverflow.com/questions/3902635/how-does-one-capture-a-macs-command-key-via-javascript#comment15734641_5500536 it should be attached to keydown event. It works for me with this change.
