### PR TITLE
Add support for package main

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
@@ -18,18 +19,26 @@ func (e *Engine) Gen(input string) string {
 	imports := []string{}
 	statements := []string{}
 
-	for _, line := range strings.Split(input, "\n") {
-		if strings.HasPrefix(line, "import ") {
-			imports = append(imports, line)
-		} else {
-			statements = append(statements, line)
+	// Check code starts with "package main"
+	if m, _ := regexp.MatchString("^\\s*package\\s+main\\s*", input); m {
+		// No preprocessing required
+		return input
+	} else {
+		// Append package and all import
+		for _, line := range strings.Split(input, "\n") {
+			if strings.HasPrefix(line, "import ") {
+				imports = append(imports, line)
+			} else {
+				statements = append(statements, line)
+			}
 		}
+
+		generated := "package main\n"
+		generated = generated + strings.Join(imports, "\n") + "\n"
+		generated = generated + "func main() {\n" + strings.Join(statements, "\n") + "\n}"
+		return generated
 	}
 
-	generated := "package main\n"
-	generated = generated + strings.Join(imports, "\n") + "\n"
-	generated = generated + "func main() {\n" + strings.Join(statements, "\n") + "\n}"
-	return generated
 }
 
 func (e *Engine) Save(code string) (string, string) {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -23,21 +23,21 @@ func (e *Engine) Gen(input string) string {
 	if m, _ := regexp.MatchString("^\\s*package\\s+main\\s*", input); m {
 		// No preprocessing required
 		return input
-	} else {
-		// Append package and all import
-		for _, line := range strings.Split(input, "\n") {
-			if strings.HasPrefix(line, "import ") {
-				imports = append(imports, line)
-			} else {
-				statements = append(statements, line)
-			}
-		}
-
-		generated := "package main\n"
-		generated = generated + strings.Join(imports, "\n") + "\n"
-		generated = generated + "func main() {\n" + strings.Join(statements, "\n") + "\n}"
-		return generated
 	}
+
+	// Append package and all import
+	for _, line := range strings.Split(input, "\n") {
+		if strings.HasPrefix(line, "import ") {
+			imports = append(imports, line)
+		} else {
+			statements = append(statements, line)
+		}
+	}
+
+	generated := "package main\n"
+	generated = generated + strings.Join(imports, "\n") + "\n"
+	generated = generated + "func main() {\n" + strings.Join(statements, "\n") + "\n}"
+	return generated
 
 }
 


### PR DESCRIPTION
If the code starts with `package main` ignore the preprocessing, if not, continue with the existing flow.
