### PR TITLE
more idiomatic workdir specification

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -107,11 +107,10 @@ func (e *Engine) Run(input string) (string, error) {
 		path, _ := e.Save(e.Gen(code))
 		defer e.CleanUp(path)
 
-		os.Chdir(path)
-
 		cmdName := "go"
 		cmdArgs := []string{"run", "main.go"}
 		cmd := exec.Command(cmdName, cmdArgs...)
+		cmd.Dir = path
 		cmd.Stdout = w
 		cmd.Stderr = w
 


### PR DESCRIPTION
`exec.Command` has it's own workdir property, it's better to set that than to change the whole program's workdir, which might affect subsequent commands
