### PR TITLE
docker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ go get -u github.com/huytd/go-play
 That's all! (Given that you have a working `GOPATH` configured)
 
 Or run in Docker container:
+
 ```
 docker build -t go-play .
 # may be: docker push ...
-docker run -d -p 3000:3000 go-play
+docker run -d -p 3000:3000 go-play -mode web
 ```
 
 ## What is this?


### PR DESCRIPTION
Shouldn't the docker example use the `-mode web`? Without that, you should pipe the input into `go-play`, which is not possible the way it's described in the README / in the Docker example
