### PR TITLE
Updated .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: go
 go:
-  - 1.6.2
+  - 1.x


### PR DESCRIPTION
Use the latest stable Go version (https://docs.travis-ci.com/user/languages/go/#Specifying-a-Go-version-to-use)